### PR TITLE
Update filtering relations name to url safe names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Layout/LineLength:
 
 Metrics/AbcSize:
   Exclude:
+    - lib/warped/queries/filter.rb
     - "lib/warped/emails/components/**/*.rb"
 
 Metrics/BlockLength:
@@ -32,6 +33,8 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   Max: 20
+  Exclude:
+    - lib/warped/queries/filter.rb
 
 Style/OptionalArguments:
   Exclude:

--- a/docs/controllers/FILTERABLE.md
+++ b/docs/controllers/FILTERABLE.md
@@ -94,16 +94,16 @@ GET /users?name[]=John&name[]=Jane # returns users where the name is in ('John',
 GET /users?age.rel=is_null # returns users where the age is null
 GET /users?age.rel=is_not_null # returns users where the age is not null
 GET /users?age.rel=between&age[]=18&age[]=30 # returns users with age between 18 and 30
-GET /users?age.rel=%3E%0A&age=18 # returns users with age greater than 18, %3E%0A is url encoded for ">"
+GET /users?age.rel=gt&age=18 # returns users with age greater than 18
 ```
 
 The full list of filter relations is:
-- `=` (default) - equals
-- `!=` - not equals
-- `>` - greater than
-- `>=` - greater than or equals
-- `<` - less than
-- `<=` - less than or equals
+- `eq` (default) - equals
+- `neq` - not equals
+- `gt` - greater than
+- `gte` - greater than or equals
+- `lt` - less than
+- `lte` - less than or equals
 - `between` - between (requires two values)
 - `in` - in (default when multiple values are provided)
 - `not_in` - not in (requires multiple values)

--- a/lib/warped/controllers/filterable.rb
+++ b/lib/warped/controllers/filterable.rb
@@ -112,7 +112,7 @@ module Warped
           {
             field:,
             value: filter_value(filter_opt),
-            relation: filter_rel_value(filter_opt).presence || (filter_value(filter_opt).is_a?(Array) ? "in" : "=")
+            relation: filter_rel_value(filter_opt).presence || (filter_value(filter_opt).is_a?(Array) ? "in" : "eq")
           }
         end
       end

--- a/lib/warped/controllers/filterable.rb
+++ b/lib/warped/controllers/filterable.rb
@@ -25,7 +25,7 @@ module Warped
     #   GET /users?name=John
     #   GET /users?created_at=2020-01-01
     #   GET /users?accounts.kind=premium
-    #   GET /users?accounts.kind=premium&accounts.kind.rel=not_eq
+    #   GET /users?accounts.kind=premium&accounts.kind.rel=neq
     #
     # Filters can be combined:
     #   GET /users?name=John&created_at=2020-01-01
@@ -64,9 +64,9 @@ module Warped
     # To use the operands, you must pass a parameter appended with `.rel`, and the value of a valid operand.
     #
     # Example requests:
-    #   GET /users?created_at=2020-01-01&created_at.rel=>
-    #   GET /users?created_at=2020-01-01&created_at.rel=<
-    #   GET /users?created_at=2020-01-01&created_at.rel=not_eq
+    #   GET /users?created_at=2020-01-01&created_at.rel=gt
+    #   GET /users?created_at=2020-01-01&created_at.rel=lt
+    #   GET /users?created_at=2020-01-01&created_at.rel=neq
     #
     # When the operand relation requires multiple values, like +in+, +not_in+, or +between+,
     # you can pass an array of values.

--- a/lib/warped/queries/filter.rb
+++ b/lib/warped/queries/filter.rb
@@ -10,22 +10,22 @@ module Warped
     # This class provides a simple interface for filtering a scope by a set of conditions.
     # The conditions are passed as an array of hashes, where each hash contains the following
     # keys:
-    # - +relation+: the relation to use for the filter (e.g. "=", ">", "in", etc.)
+    # - +relation+: the relation to use for the filter (e.g. "eq", "gt", "in", etc.)
     # - +field+: the field to filter by
     # - +value+: the value to filter by
     #
     #
     # @example Filter a scope by a set of conditions
     #   Warped::Queries::Filter.call(User.all, filter_conditions: [
-    #     { relation: "=", field: :first_name, value: "John" },
-    #     { relation: ">", field: :age, value: 18 }
+    #     { relation: "eq", field: :first_name, value: "John" },
+    #     { relation: "gt", field: :age, value: 18 }
     #   ])
     #   # => #<ActiveRecord::Relation [...]>
     #
     # @see RELATIONS
     # To see the list of available relations, check the +RELATIONS+ constant.
     class Filter
-      RELATIONS = %w[= != > >= < <= between in not_in starts_with ends_with contains is_null is_not_null].freeze
+      RELATIONS = %w[eq neq gt gte lt lte between in not_in starts_with ends_with contains is_null is_not_null].freeze
 
       # @param scope [ActiveRecord::Relation] the scope to filter
       # @param filter_conditions [Array<Hash>] the conditions to filter by
@@ -66,9 +66,9 @@ module Warped
 
       def filtered_scope(scope, relation, field, value)
         case relation
-        when "=", "in"
+        when "eq", "in"
           scope.where(field => value)
-        when "!=", "not_in"
+        when "neq", "not_in"
           scope.where.not(field => value)
         when "between"
           scope.where("#{field} BETWEEN ? AND ?", value.first, value.last)
@@ -82,8 +82,14 @@ module Warped
           scope.where(field => nil)
         when "is_not_null"
           scope.where.not(field => nil)
-        else # '>', '>=', '<', '<='
-          scope.where("#{field} #{relation} ?", value)
+        when "gt"
+          scope.where("? > ?", field, value)
+        when "gte"
+          scope.where(field => value..)
+        when "lt"
+          scope.where(field => ...value)
+        when "lte"
+          scope.where(field => ..value)
         end
       end
     end

--- a/spec/warped/controllers/filterable_spec.rb
+++ b/spec/warped/controllers/filterable_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Warped::Controllers::Filterable, type: :controller do
                                                                          {
                                                                            field: :email,
                                                                            value: "sample@test.com",
-                                                                           relation: "="
+                                                                           relation: "eq"
                                                                          }
                                                                        ])
         end
@@ -51,8 +51,8 @@ RSpec.describe Warped::Controllers::Filterable, type: :controller do
 
       context "when passing mapped filter names" do
         let(:params) do
-          { "signed_up_at" => "2020-01-01", "signed_up_at.rel" => ">=", "last_updated_at" => "2020-01-01",
-            "last_updated_at.rel": "<=" }
+          { "signed_up_at" => "2020-01-01", "signed_up_at.rel" => "gte", "last_updated_at" => "2020-01-01",
+            "last_updated_at.rel": "lte" }
         end
 
         it "calls Warped::Queries::Filter with correct params" do
@@ -62,12 +62,12 @@ RSpec.describe Warped::Controllers::Filterable, type: :controller do
                                                                          {
                                                                            field: "users.created_at",
                                                                            value: "2020-01-01",
-                                                                           relation: ">="
+                                                                           relation: "gte"
                                                                          },
                                                                          {
                                                                            field: :updated_at,
                                                                            value: "2020-01-01",
-                                                                           relation: "<="
+                                                                           relation: "lte"
                                                                          }
                                                                        ])
         end

--- a/spec/warped/controllers/tabulate_spec.rb
+++ b/spec/warped/controllers/tabulate_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Warped::Controllers::Tabulatable, type: :controller do
           expect(Warped::Queries::Filter).to have_received(:call).with(scope,
                                                                        filter_conditions: [{
                                                                          field: :email,
-                                                                         relation: "=",
+                                                                         relation: "eq",
                                                                          value: "john@sample.com"
                                                                        }])
         end
@@ -140,7 +140,7 @@ RSpec.describe Warped::Controllers::Tabulatable, type: :controller do
                                                                        filter_conditions: [{
                                                                          field: :email,
                                                                          value: "john@sample.com",
-                                                                         relation: "="
+                                                                         relation: "eq"
                                                                        }])
         end
 

--- a/spec/warped/queries/filter_spec.rb
+++ b/spec/warped/queries/filter_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Warped::Queries::Filter do
     context "when filter_conditions is not empty" do
       let(:filter_conditions) { [{ relation:, field: "id", value: }] }
 
-      context "when relation is =" do
+      context "when relation is eq" do
         let(:value) { 1 }
-        let(:relation) { "=" }
+        let(:relation) { "eq" }
 
         it "filters the scope by the given filter conditions" do
           expect(scope).to receive(:where).with("id" => 1)
@@ -28,9 +28,9 @@ RSpec.describe Warped::Queries::Filter do
         end
       end
 
-      context "when relation is !=" do
+      context "when relation is neq" do
         let(:value) { 1 }
-        let(:relation) { "!=" }
+        let(:relation) { "neq" }
 
         before { allow(scope).to receive_message_chain(:where, :not) }
 
@@ -41,16 +41,47 @@ RSpec.describe Warped::Queries::Filter do
         end
       end
 
-      %w[> >= < <=].each do |relation|
-        context "when relation is #{relation}" do
-          let(:value) { 1 }
-          let(:relation) { relation }
+      context "when relation is gt" do
+        let(:value) { 1 }
+        let(:relation) { "gt" }
 
-          it "filters the scope by the given filter conditions" do
-            expect(scope).to receive(:where).with("id #{relation} ?", 1)
+        it "filters the scope by the given filter conditions" do
+          expect(scope).to receive(:where).with("? > ?", "id", 1)
 
-            filter
-          end
+          filter
+        end
+      end
+
+      context "when relation is gte" do
+        let(:value) { 1 }
+        let(:relation) { "gte" }
+
+        it "filters the scope by the given filter conditions" do
+          expect(scope).to receive(:where).with("id" => 1..)
+
+          filter
+        end
+      end
+
+      context "when relation is lt" do
+        let(:value) { 1 }
+        let(:relation) { "lt" }
+
+        it "filters the scope by the given filter conditions" do
+          expect(scope).to receive(:where).with("id" => ...1)
+
+          filter
+        end
+      end
+
+      context "when relation is lte" do
+        let(:value) { 1 }
+        let(:relation) { "lte" }
+
+        it "filters the scope by the given filter conditions" do
+          expect(scope).to receive(:where).with("id" => ..1)
+
+          filter
         end
       end
 
@@ -135,8 +166,8 @@ RSpec.describe Warped::Queries::Filter do
     context "when filter_conditions contains multiple conditions" do
       let(:filter_conditions) do
         [
-          { relation: "=", field: "id", value: 1 },
-          { relation: "=", field: "name", value: "test" }
+          { relation: "eq", field: "id", value: 1 },
+          { relation: "eq", field: "name", value: "test" }
         ]
       end
 


### PR DESCRIPTION
- Change url unsafe filter relations name to url-safe names:
  - `=` -> `eq`
  - `!=` -> `neq`
  - `>` -> `gt`
  - `>=` -> `gte`
  - `<` -> `lt`
  - `<=` -> `lte`